### PR TITLE
ADIOS2 and array index mapping

### DIFF
--- a/include/bout/mesh.hxx
+++ b/include/bout/mesh.hxx
@@ -503,8 +503,19 @@ public:
   int GlobalNx, GlobalNy, GlobalNz; ///< Size of the global arrays. Note: can have holes
   /// Size of the global arrays excluding boundary points.
   int GlobalNxNoBoundaries, GlobalNyNoBoundaries, GlobalNzNoBoundaries;
+
+  /// Note: These offsets only correct if Y guards are not included in the global array
+  ///       and are corrected in gridfromfile.cxx
   int OffsetX, OffsetY, OffsetZ; ///< Offset of this mesh within the global array
                                  ///< so startx on this processor is OffsetX in global
+
+  /// Map between local and global indices
+  /// (MapGlobalX, MapGlobalY, MapGlobalZ) in the global index space maps to (MapLocalX, MapLocalY, MapLocalZ) locally.
+  /// Note that boundary cells are included in the global index space, but communication
+  /// guard cells are not.
+  int MapGlobalX, MapGlobalY, MapGlobalZ; ///< Start global indices
+  int MapLocalX, MapLocalY, MapLocalZ;    ///< Start local indices
+  int MapCountX, MapCountY, MapCountZ;    ///< Size of the mapped region
 
   /// Returns the number of unique cells (i.e., ones not used for
   /// communication) on this processor for 3D fields. Boundaries

--- a/src/mesh/impls/bout/boutmesh.cxx
+++ b/src/mesh/impls/bout/boutmesh.cxx
@@ -333,7 +333,7 @@ void BoutMesh::setDerivedGridSizes() {
   }
 
   GlobalNx = nx;
-  GlobalNy = ny + 2 * MYG;
+  GlobalNy = ny + 2 * MYG; // Note: For double null this should be be 4 * MYG if boundary cells are stored
   GlobalNz = nz;
 
   // If we've got a second pair of diverator legs, we need an extra
@@ -374,6 +374,7 @@ void BoutMesh::setDerivedGridSizes() {
   }
 
   // Set global offsets
+  // Note: These don't properly include guard/boundary cells
   OffsetX = PE_XIND * MXSUB;
   OffsetY = PE_YIND * MYSUB;
   OffsetZ = 0;
@@ -392,6 +393,48 @@ void BoutMesh::setDerivedGridSizes() {
 
   zstart = MZG;
   zend = MZG + MZSUB - 1;
+
+  // Mapping local to global indices
+  if (periodicX) {
+    // No boundary cells in X
+    MapGlobalX = PE_XIND * MXSUB;
+    MapLocalX = MXG;
+    MapCountX = MXSUB;
+  } else {
+    // X boundaries stored for firstX and lastX processors
+    if (firstX()) {
+      MapGlobalX = 0;
+      MapLocalX = 0;
+      MapCountX = MXG + MXSUB;
+    } else {
+      MapGlobalX = MXG + PE_XIND * MXSUB;
+      MapLocalX = MXG; // Guard cells not included
+      MapCountX = MXSUB;
+    }
+    if (lastX()) {
+      // Doesn't change the origin, but adds outer X boundary cells
+      MapCountX += MXG;
+    }
+  }
+
+  if (PE_YIND == 0) {
+    // Include Y boundary cells
+    MapGlobalY = 0;
+    MapLocalY = 0;
+    MapCountY = MYG + MYSUB;
+  } else {
+    MapGlobalY = MYG + PE_YIND * MYSUB;
+    MapLocalY = MYG;
+    MapCountY = MYSUB;
+  }
+  if (PE_YIND == NYPE - 1) {
+    // Include Y upper boundary region.
+    MapCountY += MYG;
+  }
+
+  MapGlobalZ = 0;
+  MapLocalZ = MZG; // Omit boundary cells
+  MapCountZ = MZSUB;
 }
 
 int BoutMesh::load() {


### PR DESCRIPTION
In general file I/O maps a logically rectangular subset of the local (nx, ny, nz) array onto a part of a global array. That global array may be sparse i.e. there might be holes in it.

The mapping does not cover the entire local array because we insert communication guard cells around the outside.

To perform this mapping we use ADIOS Put() function to get a span of a buffer, and then iterate over fields to copy data into those buffers.